### PR TITLE
chore: update dependencies and rewrite documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,18 +34,18 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -60,21 +60,21 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -134,14 +134,14 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
 ]
 
 [[package]]
@@ -152,15 +152,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "linux-raw-sys"
@@ -185,9 +185,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -214,18 +214,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -289,9 +289,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -322,18 +322,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -342,24 +342,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"
@@ -378,77 +369,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["command-line-utilities", "config"]
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
-tempfile = "3.13"
+tempfile = "3.24"
 temp-env = "0.3"

--- a/README.md
+++ b/README.md
@@ -13,154 +13,392 @@ Traditional tools like GNU Stow excel at symlink management but lack automation 
 
 ## Features
 
-- **Symlink Management**: Stow-like symlinking from a dotfiles repository to your home or a custom directory
-- **Setup Scripts**: Run package-specific setup/teardown scripts for automated configuration
+- **Symlink Management**: GNU Stow-style symlinking from a dotfiles repository to your home directory or custom target
+- **Setup/Teardown Scripts**: Run package-specific scripts for automated configuration during install/uninstall
 - **Easy Adoption**: Migrate existing dotfiles into stau management with a single command
-- **Written in Rust**: Fast, reliable, and cross-platform
-
-## Quick Start
-
-```bash
-# Install a package (creates symlinks + runs setup script)
-stau install <package> [--target <dir>]
-
-# Adopt an existing dotfile into management
-stau adopt <package> <file...> [--target <dir>]
-
-# List managed packages
-stau list [--target <dir>]
-
-# Uninstall a package (removes symlinks, copies files back)
-stau uninstall <package> [--target <dir>]
-
-# Refresh symlinks for a package
-stau restow <package> [--target <dir>]
-```
-
-## Project Structure
-
-```
-~/dotfiles/              # Your dotfiles repository
-├── zsh/
-│   ├── .zshrc
-│   ├── .zshenv
-│   ├── setup.sh         # Optional: runs on 'stau install zsh'
-│   └── teardown.sh      # Optional: runs on 'stau uninstall zsh'
-├── nvim/
-│   └── .config/
-│       └── nvim/
-│           └── init.lua
-└── git/
-    └── .gitconfig
-```
-
-## Commands
-
-**`stau install <package>`**
-Creates symlinks from `~/dotfiles/<package>/` to your home directory and runs the package's `setup.sh` script if it exists.
-
-**`stau uninstall <package>`**
-Runs `teardown.sh` (if it exists), removes symlinks, and copies the actual files back to their original locations. This "unadopts" the dotfiles, leaving you with standalone config files.
-
-**`stau adopt <package> <file...>`**
-Moves existing files from your home directory into the dotfiles repository and replaces them with symlinks.
-
-```bash
-stau adopt zsh ~/.zshrc ~/.zshenv
-# Moves files to ~/dotfiles/zsh/ and creates symlinks
-```
-
-**`stau list`**
-Shows all managed packages and their status.
-
-**`stau restow <package>`**
-Removes and recreates symlinks for a package (useful after modifying the package structure).
-
-## Setup Scripts
-
-Each package can have optional scripts:
-
-- **`setup.sh`**: Run during `stau install` for initial setup (install dependencies, clone repos, etc.)
-- **`teardown.sh`**: Run during `stau uninstall` for cleanup (optional)
-
-Example `~/dotfiles/zsh/setup.sh`:
-
-```bash
-#!/bin/bash
-# Install oh-my-zsh
-if [ ! -d "$STAU_TARGET/.oh-my-zsh" ]; then
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-fi
-
-# Clone zsh plugins
-git clone https://github.com/zsh-users/zsh-autosuggestions "$STAU_TARGET/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
-```
-
-Example `~/dotfiles/zsh/teardown.sh`:
-
-```bash
-#!/bin/bash
-# Remove plugins installed during setup
-rm -rf "$STAU_TARGET/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
-```
-
-**Note**: Scripts receive these environment variables:
-
-- `STAU_DIR`: Path to your dotfiles directory
-- `STAU_PACKAGE`: Current package name
-- `STAU_TARGET`: Where symlinks are created (use this instead of hardcoding `$HOME`)
-
-## Configuration
-
-### Dotfiles Directory
-
-stau looks for your dotfiles directory at `~/dotfiles` by default. You can override this with the `STAU_DIR` environment variable:
-
-```bash
-export STAU_DIR="$HOME/.dotfiles"
-```
-
-### Target Directory
-
-By default, stau creates symlinks in your home directory (`$HOME`). You can specify a different target directory using the `--target` flag or `STAU_TARGET` environment variable:
-
-```bash
-# Test installation without affecting your real home directory
-stau install zsh --target /tmp/test-home
-
-# Manage system configs
-sudo stau install nginx --target /etc
-
-# Use environment variable
-export STAU_TARGET=/tmp/test
-stau install zsh
-stau list
-```
-
-This is useful for:
-
-- **Testing**: Try out configurations in a temporary directory
-- **Dry runs**: See what would happen without modifying your actual files
-- **System configs**: Manage `/etc` or other system directories
-- **Multiple users**: Install configs for different users
+- **Conflict Detection**: Safely detects and reports conflicts before overwriting files
+- **Dry Run Mode**: Preview changes before making them with `--dry-run`
+- **Force Mode**: Override conflicts when needed with `--force`
+- **Broken Symlink Cleanup**: Clean up stale symlinks with the `clean` command
+- **Cross-Platform**: Written in Rust for speed, reliability, and portability
 
 ## Installation
+
+### From crates.io
 
 ```bash
 cargo install stau
 ```
 
-Or build from source:
+### From source
 
 ```bash
 git clone https://github.com/mhalder/stau
 cd stau
 cargo build --release
+# Binary will be at target/release/stau
 ```
 
-## License
+### Pre-built binaries
 
-[MIT](LICENSE)
+Download pre-built binaries for Linux, macOS (Intel/Apple Silicon), and Windows from the [releases page](https://github.com/mhalder/stau/releases).
+
+## Quick Start
+
+```bash
+# Install a package (creates symlinks + runs setup script)
+stau install zsh
+
+# List all packages and their status
+stau list
+
+# Show detailed status for a specific package
+stau status zsh
+
+# Adopt existing dotfiles into stau management
+stau adopt zsh ~/.zshrc ~/.zshenv
+
+# Uninstall a package (removes symlinks, copies files back)
+stau uninstall zsh
+
+# Refresh symlinks for a package
+stau restow zsh
+
+# Clean up broken symlinks
+stau clean zsh
+```
+
+## Project Structure
+
+Organize your dotfiles in a directory structure where each subdirectory is a "package":
+
+```
+~/dotfiles/                    # Your dotfiles repository (STAU_DIR)
+├── zsh/
+│   ├── .zshrc                 # Symlinked to ~/.zshrc
+│   ├── .zshenv                # Symlinked to ~/.zshenv
+│   ├── setup.sh               # Optional: runs on 'stau install zsh'
+│   └── teardown.sh            # Optional: runs on 'stau uninstall zsh'
+├── nvim/
+│   └── .config/
+│       └── nvim/
+│           └── init.lua       # Symlinked to ~/.config/nvim/init.lua
+├── git/
+│   └── .gitconfig             # Symlinked to ~/.gitconfig
+└── tmux/
+    └── .tmux.conf             # Symlinked to ~/.tmux.conf
+```
+
+## Commands
+
+### `stau install <package>`
+
+Creates symlinks from your dotfiles package to the target directory and runs the package's `setup.sh` script if present.
+
+```bash
+stau install zsh                    # Basic install
+stau install zsh --no-setup         # Skip setup script
+stau install zsh --force            # Overwrite existing files
+stau install zsh --target /tmp/test # Install to custom directory
+stau install zsh --dry-run          # Preview without making changes
+stau install zsh --verbose          # Show detailed output
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `--no-setup` | Skip running the setup script |
+| `-f, --force` | Force install even if conflicts exist (overwrites files) |
+| `-t, --target <DIR>` | Target directory (default: `$HOME` or `$STAU_TARGET`) |
+| `-n, --dry-run` | Show what would be done without making changes |
+| `-v, --verbose` | Show detailed output |
+
+### `stau uninstall <package>`
+
+Runs `teardown.sh` (if present), removes symlinks, and copies the actual files back to their original locations. This "unadopts" the dotfiles, leaving you with standalone config files.
+
+```bash
+stau uninstall zsh                  # Basic uninstall
+stau uninstall zsh --no-teardown    # Skip teardown script
+stau uninstall zsh --force          # Force uninstall with conflicts
+stau uninstall zsh --dry-run        # Preview without making changes
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `--no-teardown` | Skip running the teardown script |
+| `--force` | Force uninstall even if conflicts exist |
+| `-t, --target <DIR>` | Target directory (default: `$HOME` or `$STAU_TARGET`) |
+| `-n, --dry-run` | Show what would be done without making changes |
+| `-v, --verbose` | Show detailed output |
+
+**Note:** If the teardown script fails, uninstall continues anyway (with a warning).
+
+### `stau restow <package>`
+
+Removes and recreates symlinks for a package. Useful after modifying the package structure or adding new files. Unlike `uninstall`, this does **not** copy files back or run teardown.
+
+```bash
+stau restow zsh                     # Refresh symlinks
+stau restow zsh --run-setup         # Also run setup script
+stau restow zsh --dry-run           # Preview changes
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `--run-setup` | Run the setup script during restow |
+| `-t, --target <DIR>` | Target directory |
+| `-n, --dry-run` | Show what would be done without making changes |
+| `-v, --verbose` | Show detailed output |
+
+### `stau adopt <package> <file...>`
+
+Moves existing files from your home directory into the dotfiles repository and replaces them with symlinks. Creates the package directory if it doesn't exist.
+
+```bash
+stau adopt zsh ~/.zshrc ~/.zshenv   # Adopt multiple files
+stau adopt vim ~/.vimrc             # Adopt single file
+stau adopt shell ~/.bashrc --dry-run # Preview adoption
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `-t, --target <DIR>` | Target directory |
+| `-n, --dry-run` | Show what would be done without making changes |
+| `-v, --verbose` | Show detailed output |
+
+### `stau list`
+
+Shows all packages in your dotfiles directory and their installation status.
+
+```bash
+stau list                           # List all packages
+stau list --target /tmp/test        # Check status against custom target
+```
+
+**Output example:**
+
+```
+Packages in /home/user/dotfiles:
+
+  git                  [installed]  1 symlink
+  nvim                 [installed]  3 symlinks
+  tmux                 [not installed]
+  vim                  [partial]    2/5 symlinks
+  zsh                  [installed]  2 symlinks  (1 broken)
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `-t, --target <DIR>` | Target directory to check status against |
+
+### `stau status <package>`
+
+Shows detailed status information for a specific package, including each file's symlink state.
+
+```bash
+stau status zsh                     # Show detailed status
+stau status vim --target /tmp/test  # Check against custom target
+```
+
+**Output example:**
+
+```
+Status for package 'zsh':
+
+  Package directory: /home/user/dotfiles/zsh
+  Target directory:  /home/user
+  Setup script:      /home/user/dotfiles/zsh/setup.sh (exists)
+  Teardown script:   (none)
+
+Files (3 total):
+  [installed]      /home/user/.zshrc
+  [installed]      /home/user/.zshenv
+  [not installed]  /home/user/.zprofile
+
+Summary: 2 installed, 1 not installed, 0 broken
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `-t, --target <DIR>` | Target directory to check status against |
+
+### `stau clean <package>`
+
+Removes broken symlinks for a package. Useful when source files have been deleted or moved.
+
+```bash
+stau clean zsh                      # Remove broken symlinks
+stau clean zsh --dry-run            # Preview what would be removed
+stau clean zsh --verbose            # Show each symlink being removed
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `-t, --target <DIR>` | Target directory |
+| `-n, --dry-run` | Show what would be done without making changes |
+| `-v, --verbose` | Show detailed output |
+
+## Setup and Teardown Scripts
+
+Each package can have optional automation scripts:
+
+- **`setup.sh`**: Runs during `stau install` for initial setup (install dependencies, clone repos, etc.)
+- **`teardown.sh`**: Runs during `stau uninstall` for cleanup
+
+### Environment Variables Available to Scripts
+
+Scripts receive these environment variables:
+
+| Variable       | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `STAU_DIR`     | Path to your dotfiles directory                                        |
+| `STAU_PACKAGE` | Current package name                                                   |
+| `STAU_TARGET`  | Target directory for symlinks (use this instead of hardcoding `$HOME`) |
+
+### Example setup.sh
+
+```bash
+#!/bin/bash
+# ~/dotfiles/zsh/setup.sh
+
+# Install oh-my-zsh if not present
+if [ ! -d "$STAU_TARGET/.oh-my-zsh" ]; then
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+fi
+
+# Clone zsh plugins
+ZSH_CUSTOM="$STAU_TARGET/.oh-my-zsh/custom"
+if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
+fi
+
+if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
+fi
+
+echo "ZSH setup complete!"
+```
+
+### Example teardown.sh
+
+```bash
+#!/bin/bash
+# ~/dotfiles/zsh/teardown.sh
+
+# Remove plugins installed during setup
+rm -rf "$STAU_TARGET/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
+rm -rf "$STAU_TARGET/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
+
+echo "ZSH teardown complete!"
+```
+
+**Important:** Make scripts executable with `chmod +x setup.sh teardown.sh`
+
+## Configuration
+
+### STAU_DIR (Dotfiles Directory)
+
+stau looks for your dotfiles at `~/dotfiles` by default. Override with the `STAU_DIR` environment variable:
+
+```bash
+export STAU_DIR="$HOME/.dotfiles"
+```
+
+### STAU_TARGET (Target Directory)
+
+By default, stau creates symlinks in your home directory (`$HOME`). Override with `--target` flag or `STAU_TARGET` environment variable:
+
+```bash
+# Using environment variable
+export STAU_TARGET="/tmp/test"
+stau install zsh
+
+# Using --target flag (takes precedence)
+stau install zsh --target /tmp/test
+```
+
+**Use cases:**
+
+- **Testing**: Try configurations in a temporary directory
+- **Dry runs**: See what would happen without modifying real files
+- **System configs**: Manage `/etc` or other system directories
+- **Multiple users**: Install configs for different users
+
+## Exit Codes
+
+stau uses specific exit codes to indicate different error conditions:
+
+| Code | Meaning                                                               |
+| ---- | --------------------------------------------------------------------- |
+| 0    | Success                                                               |
+| 1    | Package not found, STAU_DIR not found, invalid path, or general error |
+| 2    | Conflicting file exists (use `--force` to override)                   |
+| 3    | Permission denied or I/O error                                        |
+| 4    | Setup or teardown script failed                                       |
+
+## Global Options
+
+These options work with all commands:
+
+| Flag        | Short | Description                                       |
+| ----------- | ----- | ------------------------------------------------- |
+| `--verbose` | `-v`  | Enable verbose output showing detailed operations |
+| `--dry-run` | `-n`  | Show what would be done without making changes    |
+| `--help`    | `-h`  | Show help information                             |
+| `--version` | `-V`  | Show version information                          |
+
+## Ignored Files
+
+stau automatically ignores these files in package directories:
+
+- `setup.sh` and `teardown.sh` (script files)
+- `.git`, `.gitignore`, `.gitattributes`, `.gitmodules` (version control, at package root only)
+
+## Tips and Best Practices
+
+1. **Start with dry-run**: Use `--dry-run` to preview changes before making them
+2. **Use verbose mode**: Add `--verbose` when troubleshooting
+3. **Keep scripts idempotent**: Setup scripts should be safe to run multiple times
+4. **Test in isolation**: Use `--target /tmp/test` to test packages safely
+5. **Commit before changes**: If your dotfiles are in git, commit before running stau commands
+6. **Document dependencies**: Note any system dependencies in your README or setup scripts
+
+## Common Workflows
+
+### Setting up a new machine
+
+```bash
+# Clone your dotfiles
+git clone https://github.com/username/dotfiles ~/dotfiles
+
+# Install packages
+stau install zsh
+stau install nvim
+stau install git
+stau install tmux
+```
+
+### Adding a new dotfile
+
+```bash
+# Option 1: Adopt existing file
+stau adopt nvim ~/.config/nvim/lua/custom.lua
+
+# Option 2: Create in package directory, then restow
+# (edit ~/dotfiles/nvim/.config/nvim/lua/custom.lua)
+stau restow nvim
+```
+
+### Migrating from GNU Stow
+
+stau uses the same directory structure as GNU Stow. Simply set `STAU_DIR` to your existing stow directory and start using stau commands. Add `setup.sh`/`teardown.sh` scripts as needed.
 
 ## Versioning
 
@@ -172,6 +410,10 @@ This project follows [Semantic Versioning](https://semver.org/):
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
+## License
+
+[MIT](LICENSE)
+
 ## Contributing
 
-Contributions welcome! Please open an issue or pull request.
+Contributions welcome! Please open an issue or pull request on [GitHub](https://github.com/mhalder/stau).


### PR DESCRIPTION
## Summary

- Update `thiserror` from 1.0 to 2.0
- Update `tempfile` from 3.13 to 3.24
- Run `cargo update` to get latest compatible versions (17 packages updated)
- Completely rewrite README.md with comprehensive documentation

## Dependency Updates

| Package | Old | New |
|---------|-----|-----|
| thiserror | 1.0 | 2.0 |
| tempfile | 3.13 | 3.24 |
| clap | 4.5.49 | 4.5.53 |
| bitflags | 2.9.4 | 2.10.0 |
| rustix | 1.1.2 | 1.1.3 |
| + 12 more transitive deps | | |

## Documentation Improvements

The README has been completely rewritten to include:

- **All 7 commands** with complete CLI options in tables
- **Exit codes** reference (0-4)
- **Global options** table (`--verbose`, `--dry-run`, `--help`, `--version`)
- **Environment variables** table (`STAU_DIR`, `STAU_PACKAGE`, `STAU_TARGET`)
- **Setup/teardown script examples** with idempotent patterns
- **Tips and best practices** section
- **Common workflows** (new machine setup, adding dotfiles)
- **Migration guide** from GNU Stow
- **Ignored files** documentation
- **Example outputs** for `list` and `status` commands

## Test plan

- [x] All 97 tests pass (51 unit + 46 integration)
- [x] 89.26% line coverage maintained
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes

Closes #6