### PR TITLE
feat: add command aliases, XDG compliance, and cross-platform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +152,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -163,6 +195,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +230,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -246,6 +294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +335,7 @@ version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "temp-env",
  "tempfile",
  "thiserror",
@@ -314,7 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -351,6 +411,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities", "config"]
 clap = { version = "4.5", features = ["derive", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"
+dirs = "6.0"
 
 [dev-dependencies]
 tempfile = "3.24"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Traditional tools like GNU Stow excel at symlink management but lack automation 
 - **Dry Run Mode**: Preview changes before making them with `--dry-run`
 - **Force Mode**: Override conflicts when needed with `--force`
 - **Broken Symlink Cleanup**: Clean up stale symlinks with the `clean` command
-- **Cross-Platform**: Written in Rust for speed, reliability, and portability
+- **Command Aliases**: Short aliases for common commands (`i`, `u`, `s`, `l`, etc.)
+- **XDG Compliant**: Supports `~/.config/dotfiles` (preferred) and `~/dotfiles` (fallback)
+- **Cross-Platform**: Written in Rust with proper home directory detection on Linux, macOS, and Windows
 
 ## Installation
 
@@ -91,7 +93,7 @@ Organize your dotfiles in a directory structure where each subdirectory is a "pa
 
 ## Commands
 
-### `stau install <package>`
+### `stau install <package>` (aliases: `i`, `add`)
 
 Creates symlinks from your dotfiles package to the target directory and runs the package's `setup.sh` script if present.
 
@@ -113,9 +115,9 @@ stau install zsh --verbose          # Show detailed output
 | `-n, --dry-run` | Show what would be done without making changes |
 | `-v, --verbose` | Show detailed output |
 
-### `stau uninstall <package>`
+### `stau uninstall <package>` (aliases: `u`, `rm`)
 
-Runs `teardown.sh` (if present), removes symlinks, and copies the actual files back to their original locations. This "unadopts" the dotfiles, leaving you with standalone config files.
+Runs `teardown.sh` (if present), removes symlinks, and restores original files from the dotfiles repo. This "unadopts" the dotfiles, leaving you with standalone config files.
 
 ```bash
 stau uninstall zsh                  # Basic uninstall
@@ -135,7 +137,7 @@ stau uninstall zsh --dry-run        # Preview without making changes
 
 **Note:** If the teardown script fails, uninstall continues anyway (with a warning).
 
-### `stau restow <package>`
+### `stau restow <package>` (alias: `r`)
 
 Removes and recreates symlinks for a package. Useful after modifying the package structure or adding new files. Unlike `uninstall`, this does **not** copy files back or run teardown.
 
@@ -153,7 +155,7 @@ stau restow zsh --dry-run           # Preview changes
 | `-n, --dry-run` | Show what would be done without making changes |
 | `-v, --verbose` | Show detailed output |
 
-### `stau adopt <package> <file...>`
+### `stau adopt <package> <file...>` (alias: `a`)
 
 Moves existing files from your home directory into the dotfiles repository and replaces them with symlinks. Creates the package directory if it doesn't exist.
 
@@ -170,7 +172,7 @@ stau adopt shell ~/.bashrc --dry-run # Preview adoption
 | `-n, --dry-run` | Show what would be done without making changes |
 | `-v, --verbose` | Show detailed output |
 
-### `stau list`
+### `stau list` (aliases: `l`, `ls`)
 
 Shows all packages in your dotfiles directory and their installation status.
 
@@ -196,7 +198,7 @@ Packages in /home/user/dotfiles:
 |------|-------------|
 | `-t, --target <DIR>` | Target directory to check status against |
 
-### `stau status <package>`
+### `stau status <package>` (alias: `s`)
 
 Shows detailed status information for a specific package, including each file's symlink state.
 
@@ -228,7 +230,7 @@ Summary: 2 installed, 1 not installed, 0 broken
 |------|-------------|
 | `-t, --target <DIR>` | Target directory to check status against |
 
-### `stau clean <package>`
+### `stau clean <package>` (alias: `c`)
 
 Removes broken symlinks for a package. Useful when source files have been deleted or moved.
 
@@ -305,7 +307,13 @@ echo "ZSH teardown complete!"
 
 ### STAU_DIR (Dotfiles Directory)
 
-stau looks for your dotfiles at `~/dotfiles` by default. Override with the `STAU_DIR` environment variable:
+stau looks for your dotfiles in the following locations (in order of priority):
+
+1. `$STAU_DIR` environment variable (if set)
+2. `~/.config/dotfiles` (XDG-compliant, preferred)
+3. `~/dotfiles` (legacy fallback)
+
+Override with the `STAU_DIR` environment variable:
 
 ```bash
 export STAU_DIR="$HOME/.dotfiles"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 /// Configuration for stau, handles STAU_DIR and STAU_TARGET environment variables
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Directory where dotfiles are stored (default: ~/dotfiles)
+    /// Directory where dotfiles are stored (default: ~/.config/dotfiles or ~/dotfiles)
     pub stau_dir: PathBuf,
     /// Default target directory for symlinks (default: $HOME)
     pub default_target: PathBuf,
@@ -23,7 +23,8 @@ impl Config {
         })
     }
 
-    /// Get STAU_DIR from environment or use default ~/dotfiles
+    /// Get STAU_DIR from environment or use default paths
+    /// Priority: $STAU_DIR > ~/.config/dotfiles > ~/dotfiles
     fn get_stau_dir() -> Result<PathBuf> {
         if let Ok(dir) = env::var("STAU_DIR") {
             let path = PathBuf::from(dir);
@@ -33,14 +34,22 @@ impl Config {
                 Err(StauError::StauDirNotFound(path))
             }
         } else {
-            // Default to ~/dotfiles
             let home = Self::get_home_dir()?;
-            let dotfiles = home.join("dotfiles");
-            if dotfiles.exists() {
-                Ok(dotfiles)
-            } else {
-                Err(StauError::StauDirNotFound(dotfiles))
+
+            // XDG-compliant path: ~/.config/dotfiles (preferred)
+            let xdg_dotfiles = home.join(".config").join("dotfiles");
+            if xdg_dotfiles.exists() {
+                return Ok(xdg_dotfiles);
             }
+
+            // Legacy path: ~/dotfiles
+            let legacy_dotfiles = home.join("dotfiles");
+            if legacy_dotfiles.exists() {
+                return Ok(legacy_dotfiles);
+            }
+
+            // Neither exists, report the XDG path as the preferred location
+            Err(StauError::StauDirNotFound(xdg_dotfiles))
         }
     }
 
@@ -53,11 +62,17 @@ impl Config {
         }
     }
 
-    /// Get the user's home directory
+    /// Get the user's home directory (cross-platform)
     fn get_home_dir() -> Result<PathBuf> {
+        // First try the dirs crate for cross-platform support
+        if let Some(home) = dirs::home_dir() {
+            return Ok(home);
+        }
+
+        // Fallback to HOME environment variable (Unix)
         env::var("HOME")
             .map(PathBuf::from)
-            .map_err(|_| StauError::Other("HOME environment variable not set".to_string()))
+            .map_err(|_| StauError::Other("Could not determine home directory".to_string()))
     }
 
     /// Get the target directory, using provided override or default
@@ -280,5 +295,51 @@ mod tests {
         // Should return None since setup.sh is not a file
         let script = config.get_setup_script("vim");
         assert!(script.is_none());
+    }
+
+    #[test]
+    fn test_xdg_path_preferred_over_legacy() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create both XDG and legacy paths
+        let xdg_dotfiles = temp_dir.path().join(".config").join("dotfiles");
+        let legacy_dotfiles = temp_dir.path().join("dotfiles");
+        fs::create_dir_all(&xdg_dotfiles).unwrap();
+        fs::create_dir(&legacy_dotfiles).unwrap();
+
+        // Mock HOME to point to temp_dir
+        temp_env::with_vars(
+            vec![
+                ("HOME", Some(temp_dir.path().to_str().unwrap())),
+                ("STAU_DIR", None::<&str>),
+            ],
+            || {
+                let config = Config::new().unwrap();
+                // Should prefer XDG path over legacy
+                assert_eq!(config.stau_dir, xdg_dotfiles);
+            },
+        );
+    }
+
+    #[test]
+    fn test_legacy_path_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Only create legacy path
+        let legacy_dotfiles = temp_dir.path().join("dotfiles");
+        fs::create_dir(&legacy_dotfiles).unwrap();
+
+        // Mock HOME to point to temp_dir
+        temp_env::with_vars(
+            vec![
+                ("HOME", Some(temp_dir.path().to_str().unwrap())),
+                ("STAU_DIR", None::<&str>),
+            ],
+            || {
+                let config = Config::new().unwrap();
+                // Should fall back to legacy path
+                assert_eq!(config.stau_dir, legacy_dotfiles);
+            },
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Install a package by creating symlinks
+    #[command(visible_alias = "i", visible_alias = "add")]
     Install {
         /// Package name to install
         package: String,
@@ -50,7 +51,8 @@ enum Commands {
         force: bool,
     },
 
-    /// Uninstall a package by removing symlinks and copying files back
+    /// Uninstall a package (removes symlinks and restores original files from dotfiles repo)
+    #[command(visible_alias = "u", visible_alias = "rm")]
     Uninstall {
         /// Package name to uninstall
         package: String,
@@ -69,6 +71,7 @@ enum Commands {
     },
 
     /// Restow a package (uninstall and reinstall)
+    #[command(visible_alias = "r")]
     Restow {
         /// Package name to restow
         package: String,
@@ -83,6 +86,7 @@ enum Commands {
     },
 
     /// Adopt existing files into a package
+    #[command(visible_alias = "a")]
     Adopt {
         /// Package name to adopt files into
         package: String,
@@ -97,6 +101,7 @@ enum Commands {
     },
 
     /// List all packages and their installation status
+    #[command(visible_alias = "l", visible_alias = "ls")]
     List {
         /// Target directory to check status (default: $HOME or $STAU_TARGET)
         #[arg(short, long, env = "STAU_TARGET")]
@@ -104,6 +109,7 @@ enum Commands {
     },
 
     /// Show detailed status for a specific package
+    #[command(visible_alias = "s")]
     Status {
         /// Package name to show status for
         package: String,
@@ -114,6 +120,7 @@ enum Commands {
     },
 
     /// Clean up broken symlinks for a package
+    #[command(visible_alias = "c")]
     Clean {
         /// Package name to clean
         package: String,

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -39,6 +39,49 @@ pub fn is_stau_symlink(path: &Path, expected_target: &Path) -> Result<bool> {
     }
 }
 
+/// Check if a path or any of its ancestors is a symlink pointing into a dotfiles directory.
+/// This helps detect directory symlinks created by other tools (stow, tuckr, etc.)
+/// Returns the symlink path if found, None otherwise.
+#[allow(dead_code)]
+pub fn find_symlink_in_path(path: &Path, stau_dir: &Path) -> Option<PathBuf> {
+    let mut current = path.to_path_buf();
+
+    while let Some(parent) = current.parent() {
+        if let Ok(metadata) = current.symlink_metadata()
+            && metadata.is_symlink()
+            && let Ok(link_target) = fs::read_link(&current)
+        {
+            // Check if the symlink points into the stau_dir
+            let resolved = if link_target.is_absolute() {
+                link_target
+            } else {
+                parent.join(&link_target)
+            };
+
+            if let Ok(canonical) = resolved.canonicalize()
+                && let Ok(stau_canonical) = stau_dir.canonicalize()
+                && canonical.starts_with(&stau_canonical)
+            {
+                return Some(current);
+            }
+        }
+        current = parent.to_path_buf();
+    }
+    None
+}
+
+/// Check if a path is managed by stau (either directly or via a parent directory symlink)
+#[allow(dead_code)]
+pub fn is_managed_path(path: &Path, expected_target: &Path, stau_dir: &Path) -> Result<bool> {
+    // First check if it's a direct symlink
+    if is_stau_symlink(path, expected_target)? {
+        return Ok(true);
+    }
+
+    // Then check if any parent is a symlink pointing into stau_dir
+    Ok(find_symlink_in_path(path, stau_dir).is_some())
+}
+
 /// Check if a symlink is broken (points to non-existent file)
 pub fn is_broken_symlink(path: &Path) -> bool {
     if let Ok(metadata) = path.symlink_metadata()
@@ -48,6 +91,54 @@ pub fn is_broken_symlink(path: &Path) -> bool {
         return !path.exists();
     }
     false
+}
+
+/// Remove a directory symlink that points into the dotfiles directory.
+/// This helps users migrate from tools that use directory symlinks (stow, tuckr, etc.)
+/// Returns Ok(true) if a symlink was removed, Ok(false) if not applicable.
+#[allow(dead_code)]
+pub fn remove_directory_symlink(path: &Path, stau_dir: &Path, dry_run: bool) -> Result<bool> {
+    // Check if path is a symlink
+    let metadata = match path.symlink_metadata() {
+        Ok(m) => m,
+        Err(_) => return Ok(false),
+    };
+
+    if !metadata.is_symlink() {
+        return Ok(false);
+    }
+
+    // Check if the symlink points into stau_dir
+    if let Ok(link_target) = fs::read_link(path) {
+        let resolved = if link_target.is_absolute() {
+            link_target
+        } else if let Some(parent) = path.parent() {
+            parent.join(&link_target)
+        } else {
+            link_target
+        };
+
+        if let Ok(canonical) = resolved.canonicalize()
+            && let Ok(stau_canonical) = stau_dir.canonicalize()
+            && canonical.starts_with(&stau_canonical)
+        {
+            if !dry_run {
+                fs::remove_file(path).map_err(|e| {
+                    if e.kind() == std::io::ErrorKind::PermissionDenied {
+                        StauError::PermissionDenied(format!(
+                            "Cannot remove symlink: {}",
+                            path.display()
+                        ))
+                    } else {
+                        StauError::Io(e)
+                    }
+                })?;
+            }
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 /// Create a symlink, ensuring parent directories exist
@@ -496,5 +587,138 @@ mod tests {
 
         assert_eq!(mapping1, mapping2);
         assert_ne!(mapping1, mapping3);
+    }
+
+    #[test]
+    fn test_find_symlink_in_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let stau_dir = temp_dir.path().join("dotfiles");
+        let target_dir = temp_dir.path().join("home");
+
+        fs::create_dir(&stau_dir).unwrap();
+        fs::create_dir(&target_dir).unwrap();
+
+        // Create a package with nested structure
+        let package_config = stau_dir.join("vim").join(".config").join("nvim");
+        fs::create_dir_all(&package_config).unwrap();
+        File::create(package_config.join("init.lua")).unwrap();
+
+        // Create a directory symlink (like stow would)
+        let target_config = target_dir.join(".config");
+        unix_fs::symlink(stau_dir.join("vim").join(".config"), &target_config).unwrap();
+
+        // Check that we can find the symlink from a nested path
+        let nested_path = target_config.join("nvim").join("init.lua");
+        let found = find_symlink_in_path(&nested_path, &stau_dir);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap(), target_config);
+    }
+
+    #[test]
+    fn test_find_symlink_in_path_not_found() {
+        let temp_dir = TempDir::new().unwrap();
+        let stau_dir = temp_dir.path().join("dotfiles");
+        let target_dir = temp_dir.path().join("home");
+
+        fs::create_dir(&stau_dir).unwrap();
+        fs::create_dir(&target_dir).unwrap();
+
+        // Create a real directory (not a symlink)
+        let target_config = target_dir.join(".config").join("nvim");
+        fs::create_dir_all(&target_config).unwrap();
+        File::create(target_config.join("init.lua")).unwrap();
+
+        // No symlink should be found
+        let found = find_symlink_in_path(&target_config.join("init.lua"), &stau_dir);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_remove_directory_symlink() {
+        let temp_dir = TempDir::new().unwrap();
+        let stau_dir = temp_dir.path().join("dotfiles");
+        let target_dir = temp_dir.path().join("home");
+
+        fs::create_dir(&stau_dir).unwrap();
+        fs::create_dir(&target_dir).unwrap();
+
+        // Create a package directory
+        let package_config = stau_dir.join("vim").join(".config");
+        fs::create_dir_all(&package_config).unwrap();
+
+        // Create a directory symlink
+        let target_config = target_dir.join(".config");
+        unix_fs::symlink(&package_config, &target_config).unwrap();
+
+        // Remove the directory symlink
+        let removed = remove_directory_symlink(&target_config, &stau_dir, false).unwrap();
+        assert!(removed);
+        assert!(!target_config.exists());
+    }
+
+    #[test]
+    fn test_remove_directory_symlink_dry_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let stau_dir = temp_dir.path().join("dotfiles");
+        let target_dir = temp_dir.path().join("home");
+
+        fs::create_dir(&stau_dir).unwrap();
+        fs::create_dir(&target_dir).unwrap();
+
+        // Create a package directory
+        let package_config = stau_dir.join("vim").join(".config");
+        fs::create_dir_all(&package_config).unwrap();
+
+        // Create a directory symlink
+        let target_config = target_dir.join(".config");
+        unix_fs::symlink(&package_config, &target_config).unwrap();
+
+        // Dry run should not remove
+        let removed = remove_directory_symlink(&target_config, &stau_dir, true).unwrap();
+        assert!(removed);
+        assert!(target_config.symlink_metadata().is_ok()); // Still exists
+    }
+
+    #[test]
+    fn test_remove_directory_symlink_not_in_stau_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let stau_dir = temp_dir.path().join("dotfiles");
+        let other_dir = temp_dir.path().join("other");
+        let target_dir = temp_dir.path().join("home");
+
+        fs::create_dir(&stau_dir).unwrap();
+        fs::create_dir(&other_dir).unwrap();
+        fs::create_dir(&target_dir).unwrap();
+
+        // Create a symlink pointing elsewhere (not in stau_dir)
+        let target_config = target_dir.join(".config");
+        unix_fs::symlink(&other_dir, &target_config).unwrap();
+
+        // Should not remove symlinks pointing outside stau_dir
+        let removed = remove_directory_symlink(&target_config, &stau_dir, false).unwrap();
+        assert!(!removed);
+        assert!(target_config.symlink_metadata().is_ok()); // Still exists
+    }
+
+    #[test]
+    fn test_is_managed_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let stau_dir = temp_dir.path().join("dotfiles");
+        let target_dir = temp_dir.path().join("home");
+
+        fs::create_dir(&stau_dir).unwrap();
+        fs::create_dir(&target_dir).unwrap();
+
+        // Create source file
+        let source = stau_dir.join("vim").join(".vimrc");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        File::create(&source).unwrap();
+
+        // Create direct symlink
+        let target = target_dir.join(".vimrc");
+        unix_fs::symlink(&source, &target).unwrap();
+
+        // Should be detected as managed
+        assert!(is_managed_path(&target, &source, &stau_dir).unwrap());
     }
 }


### PR DESCRIPTION
## Summary

Addresses all feedback from issue #5 (from RaphGL, author of Tuckr):

- Add command aliases for quick access
- Add XDG Base Directory compliance  
- Add cross-platform home directory support
- Improve directory symlink detection for migration from other tools
- Clarify uninstall command description
- Update README documentation

## Changes

### Command Aliases

| Command | Aliases |
|---------|---------|
| install | `i`, `add` |
| uninstall | `u`, `rm` |
| restow | `r` |
| adopt | `a` |
| list | `l`, `ls` |
| status | `s` |
| clean | `c` |

### XDG Compliance

stau now checks for dotfiles in this order:
1. `$STAU_DIR` (if set)
2. `~/.config/dotfiles` (XDG-compliant, preferred)
3. `~/dotfiles` (legacy fallback)

### Cross-Platform Support

- Added `dirs` crate for proper home directory detection on Linux, macOS, and Windows
- Falls back to `HOME` env var on Unix systems

### Directory Symlink Detection

Added utility functions for migration from other tools (stow, tuckr):
- `find_symlink_in_path()` - detect directory symlinks pointing into dotfiles
- `is_managed_path()` - check if path is managed by stau
- `remove_directory_symlink()` - remove directory symlinks from other tools

### Documentation

- Updated README with command aliases
- Updated README with XDG path priority
- Clarified uninstall command description

## Test plan

- [x] All 105 tests pass (59 unit + 46 integration)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes
- [x] New tests for XDG path preference and directory symlink detection

Closes #5