### PR TITLE
fix: correct Rust edition and clean up codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,7 +327,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "stau"
 version = "2.0.0"
 dependencies = [
- "anyhow",
  "clap",
  "dirs",
  "temp-env",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stau"
 version = "2.0.0"
-edition = "2024"
+edition = "2021"
 license = "MIT"
 authors = ["mhalder"]
 repository = "https://github.com/mhalder/stau"
@@ -14,7 +14,6 @@ categories = ["command-line-utilities", "config"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
-anyhow = "1.0"
 thiserror = "2.0"
 dirs = "6.0"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,12 @@ pub struct Config {
 }
 
 impl Config {
-    /// Create a new Config by reading environment variables
+    /// Creates a new Config by reading environment variables and resolving default paths.
+    ///
+    /// STAU_DIR resolution priority:
+    /// 1. `$STAU_DIR` environment variable
+    /// 2. `~/.config/dotfiles` (XDG-compliant)
+    /// 3. `~/dotfiles` (legacy)
     pub fn new() -> Result<Self> {
         let stau_dir = Self::get_stau_dir()?;
         let default_target = Self::get_default_target()?;
@@ -75,22 +80,27 @@ impl Config {
             .map_err(|_| StauError::Other("Could not determine home directory".to_string()))
     }
 
-    /// Get the target directory, using provided override or default
+    /// Gets the target directory, using provided override or the default target.
+    ///
+    /// If an override is provided, it takes precedence over the default target
+    /// (which is `$STAU_TARGET` or `$HOME`).
     pub fn get_target(&self, override_target: Option<PathBuf>) -> PathBuf {
         override_target.unwrap_or_else(|| self.default_target.clone())
     }
 
-    /// Get the package directory path
+    /// Gets the full path to a package directory within STAU_DIR.
     pub fn get_package_dir(&self, package: &str) -> PathBuf {
         self.stau_dir.join(package)
     }
 
-    /// Check if a package exists
+    /// Checks if a package exists (i.e., its directory exists in STAU_DIR).
     pub fn package_exists(&self, package: &str) -> bool {
         self.get_package_dir(package).exists()
     }
 
-    /// Get the setup script path for a package
+    /// Gets the setup script path for a package, if it exists.
+    ///
+    /// Returns `Some(path)` if `<package>/setup.sh` exists and is a file, `None` otherwise.
     pub fn get_setup_script(&self, package: &str) -> Option<PathBuf> {
         let script_path = self.get_package_dir(package).join("setup.sh");
         if script_path.exists() && script_path.is_file() {
@@ -100,7 +110,9 @@ impl Config {
         }
     }
 
-    /// Get the teardown script path for a package
+    /// Gets the teardown script path for a package, if it exists.
+    ///
+    /// Returns `Some(path)` if `<package>/teardown.sh` exists and is a file, `None` otherwise.
     pub fn get_teardown_script(&self, package: &str) -> Option<PathBuf> {
         let script_path = self.get_package_dir(package).join("teardown.sh");
         if script_path.exists() && script_path.is_file() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,7 @@ pub enum StauError {
 }
 
 impl StauError {
+    /// Returns the appropriate exit code for this error type.
     pub fn exit_code(&self) -> i32 {
         match self {
             StauError::PackageNotFound(_) => 1,
@@ -59,6 +60,17 @@ impl StauError {
             StauError::Io(_) => 3,
             StauError::Other(_) => 1,
         }
+    }
+}
+
+/// Maps an IO error to StauError, converting PermissionDenied to StauError::PermissionDenied.
+///
+/// This helper reduces duplication when mapping IO errors throughout the codebase.
+pub fn map_io_error(e: std::io::Error, context: impl Into<String>) -> StauError {
+    if e.kind() == std::io::ErrorKind::PermissionDenied {
+        StauError::PermissionDenied(context.into())
+    } else {
+        StauError::Io(e)
     }
 }
 
@@ -153,5 +165,20 @@ mod tests {
         let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied");
         let stau_err: StauError = io_err.into();
         assert_eq!(stau_err.exit_code(), 3);
+    }
+
+    #[test]
+    fn test_map_io_error_permission_denied() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied");
+        let stau_err = map_io_error(io_err, "Cannot write file");
+        assert!(matches!(stau_err, StauError::PermissionDenied(_)));
+        assert!(stau_err.to_string().contains("Cannot write file"));
+    }
+
+    #[test]
+    fn test_map_io_error_other() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let stau_err = map_io_error(io_err, "Cannot write file");
+        assert!(matches!(stau_err, StauError::Io(_)));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod script;
 mod symlink;
 
 use config::Config;
-use error::Result;
+use error::{map_io_error, Result};
 
 #[derive(Parser)]
 #[command(name = "stau")]
@@ -211,6 +211,9 @@ fn run(cli: Cli) -> Result<()> {
     }
 }
 
+/// Installs a package by creating symlinks from the package directory to the target directory.
+///
+/// If a setup script exists and `no_setup` is false, it will be executed after creating symlinks.
 fn install_package(
     config: &Config,
     package: &str,
@@ -266,35 +269,46 @@ fn install_package(
     }
 
     // Run setup script if it exists and not skipped
-    if !no_setup && let Some(setup_script) = config.get_setup_script(package) {
-        if verbose {
-            println!("Found setup script: {}", setup_script.display());
-        }
+    if !no_setup {
+        if let Some(setup_script) = config.get_setup_script(package) {
+            if verbose {
+                println!("Found setup script: {}", setup_script.display());
+            }
 
-        script::execute_script(
-            &setup_script,
-            package,
-            &config.stau_dir,
-            &target_dir,
-            dry_run,
-            verbose,
-        )?;
+            script::execute_script(
+                &setup_script,
+                package,
+                &config.stau_dir,
+                &target_dir,
+                dry_run,
+                verbose,
+            )?;
 
-        if !dry_run {
-            println!("Setup script completed successfully");
+            if !dry_run {
+                println!("Setup script completed successfully");
+            }
         }
     }
 
     Ok(())
 }
 
+/// Options for uninstall operations.
 struct UninstallOptions {
+    /// Skip running the teardown script
     no_teardown: bool,
+    /// Copy files back from package to target after removing symlinks
     copy_files_back: bool,
+    /// Dry run mode - don't make actual changes
     dry_run: bool,
+    /// Verbose output
     verbose: bool,
 }
 
+/// Uninstalls a package by removing symlinks and optionally copying files back.
+///
+/// If a teardown script exists and `no_teardown` is false, it will be executed first.
+/// Teardown script failures are logged but don't stop the uninstall process.
 fn uninstall_package(
     config: &Config,
     package: &str,
@@ -312,6 +326,7 @@ fn uninstall_package(
     uninstall_package_internal(config, package, target, opts)
 }
 
+/// Internal implementation of package uninstallation with configurable options.
 fn uninstall_package_internal(
     config: &Config,
     package: &str,
@@ -332,26 +347,26 @@ fn uninstall_package_internal(
     }
 
     // Run teardown script first if it exists and not skipped
-    if !opts.no_teardown
-        && let Some(teardown_script) = config.get_teardown_script(package)
-    {
-        if opts.verbose {
-            println!("Found teardown script: {}", teardown_script.display());
-        }
+    if !opts.no_teardown {
+        if let Some(teardown_script) = config.get_teardown_script(package) {
+            if opts.verbose {
+                println!("Found teardown script: {}", teardown_script.display());
+            }
 
-        // Note: PRD says teardown should continue even if it fails
-        if let Err(e) = script::execute_script(
-            &teardown_script,
-            package,
-            &config.stau_dir,
-            &target_dir,
-            opts.dry_run,
-            opts.verbose,
-        ) {
-            eprintln!("Warning: Teardown script failed: {}", e);
-            eprintln!("Continuing with uninstall...");
-        } else if !opts.dry_run {
-            println!("Teardown script completed successfully");
+            // Note: PRD says teardown should continue even if it fails
+            if let Err(e) = script::execute_script(
+                &teardown_script,
+                package,
+                &config.stau_dir,
+                &target_dir,
+                opts.dry_run,
+                opts.verbose,
+            ) {
+                eprintln!("Warning: Teardown script failed: {}", e);
+                eprintln!("Continuing with uninstall...");
+            } else if !opts.dry_run {
+                println!("Teardown script completed successfully");
+            }
         }
     }
 
@@ -389,6 +404,8 @@ fn uninstall_package_internal(
                 // wasn't actually removed yet
                 if !opts.dry_run && mapping.target.exists() {
                     return Err(error::StauError::ConflictingFile(mapping.target.clone()));
+                } else if opts.dry_run && opts.verbose {
+                    println!("    (conflict check skipped in dry-run)");
                 }
 
                 symlink::copy_file(&mapping.source, &mapping.target, opts.dry_run)?;
@@ -419,6 +436,7 @@ fn uninstall_package_internal(
     Ok(())
 }
 
+/// Lists all packages in STAU_DIR and their installation status.
 fn list_packages(config: &Config, target: Option<PathBuf>) -> Result<()> {
     let target_dir = config.get_target(target);
     let packages = package::list_packages(&config.stau_dir)?;
@@ -446,9 +464,10 @@ fn list_packages(config: &Config, target: Option<PathBuf>) -> Result<()> {
                     for mapping in &mappings {
                         if let Ok(is_our_link) =
                             symlink::is_stau_symlink(&mapping.target, &mapping.source)
-                            && is_our_link
                         {
-                            installed_count += 1;
+                            if is_our_link {
+                                installed_count += 1;
+                            }
                         }
 
                         if symlink::is_broken_symlink(&mapping.target) {
@@ -480,8 +499,8 @@ fn list_packages(config: &Config, target: Option<PathBuf>) -> Result<()> {
                     }
                 }
             }
-            Err(_) => {
-                println!("  {:<20} [error reading package]", pkg);
+            Err(e) => {
+                println!("  {:<20} [error: {}]", pkg, e);
             }
         }
     }
@@ -489,6 +508,7 @@ fn list_packages(config: &Config, target: Option<PathBuf>) -> Result<()> {
     Ok(())
 }
 
+/// Adopts existing files into a package by moving them to the package directory and creating symlinks.
 fn adopt_files(
     config: &Config,
     package: &str,
@@ -509,14 +529,10 @@ fn adopt_files(
         }
         if !dry_run {
             fs::create_dir_all(&package_dir).map_err(|e| {
-                if e.kind() == std::io::ErrorKind::PermissionDenied {
-                    error::StauError::PermissionDenied(format!(
-                        "Cannot create package directory: {}",
-                        package_dir.display()
-                    ))
-                } else {
-                    error::StauError::Io(e)
-                }
+                map_io_error(
+                    e,
+                    format!("Cannot create package directory: {}", package_dir.display()),
+                )
             })?;
         }
     }
@@ -584,6 +600,7 @@ fn adopt_files(
     Ok(())
 }
 
+/// Shows detailed status for a specific package including symlink states and script availability.
 fn show_status(config: &Config, package: &str, target: Option<PathBuf>) -> Result<()> {
     let target_dir = config.get_target(target);
     let package_dir = config.get_package_dir(package);
@@ -653,6 +670,7 @@ fn show_status(config: &Config, package: &str, target: Option<PathBuf>) -> Resul
     Ok(())
 }
 
+/// Removes broken symlinks for a package.
 fn clean_broken_symlinks(
     config: &Config,
     package: &str,
@@ -680,14 +698,10 @@ fn clean_broken_symlinks(
 
             if !dry_run {
                 fs::remove_file(&mapping.target).map_err(|e| {
-                    if e.kind() == std::io::ErrorKind::PermissionDenied {
-                        error::StauError::PermissionDenied(format!(
-                            "Cannot remove symlink: {}",
-                            mapping.target.display()
-                        ))
-                    } else {
-                        error::StauError::Io(e)
-                    }
+                    map_io_error(
+                        e,
+                        format!("Cannot remove symlink: {}", mapping.target.display()),
+                    )
                 })?;
             }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,9 +1,13 @@
-use crate::error::{Result, StauError};
+use crate::error::{map_io_error, Result, StauError};
 use crate::symlink::SymlinkMapping;
 use std::fs;
 use std::path::Path;
 
-/// Walk a package directory and generate symlink mappings
+/// Walks a package directory and generates symlink mappings for all files.
+///
+/// Returns a list of `SymlinkMapping` structs representing the source files in the package
+/// and their corresponding target locations. Setup/teardown scripts and version control
+/// files at the package root are excluded.
 pub fn discover_package_files(
     package_dir: &Path,
     target_dir: &Path,
@@ -31,11 +35,10 @@ fn walk_directory(
     mappings: &mut Vec<SymlinkMapping>,
 ) -> Result<()> {
     let entries = fs::read_dir(current_dir).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            StauError::PermissionDenied(format!("Cannot read directory: {}", current_dir.display()))
-        } else {
-            StauError::Io(e)
-        }
+        map_io_error(
+            e,
+            format!("Cannot read directory: {}", current_dir.display()),
+        )
     })?;
 
     for entry in entries {
@@ -81,19 +84,17 @@ fn walk_directory(
     Ok(())
 }
 
-/// List all packages in the stau directory
+/// Lists all packages in the stau directory.
+///
+/// Returns a sorted list of package names (directory names) in STAU_DIR.
+/// Hidden directories (starting with `.`) are excluded.
 pub fn list_packages(stau_dir: &Path) -> Result<Vec<String>> {
     if !stau_dir.exists() {
         return Err(StauError::StauDirNotFound(stau_dir.to_path_buf()));
     }
 
-    let entries = fs::read_dir(stau_dir).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            StauError::PermissionDenied(format!("Cannot read directory: {}", stau_dir.display()))
-        } else {
-            StauError::Io(e)
-        }
-    })?;
+    let entries = fs::read_dir(stau_dir)
+        .map_err(|e| map_io_error(e, format!("Cannot read directory: {}", stau_dir.display())))?;
 
     let mut packages = Vec::new();
     for entry in entries {
@@ -101,12 +102,12 @@ pub fn list_packages(stau_dir: &Path) -> Result<Vec<String>> {
         let path = entry.path();
 
         // Only include directories, skip hidden directories
-        if path.is_dir()
-            && let Some(name) = path.file_name()
-        {
-            let name_str = name.to_string_lossy();
-            if !name_str.starts_with('.') {
-                packages.push(name_str.to_string());
+        if path.is_dir() {
+            if let Some(name) = path.file_name() {
+                let name_str = name.to_string_lossy();
+                if !name_str.starts_with('.') {
+                    packages.push(name_str.to_string());
+                }
             }
         }
     }
@@ -135,16 +136,12 @@ mod tests {
         let mappings = discover_package_files(&package_dir, &target_dir).unwrap();
 
         assert_eq!(mappings.len(), 2);
-        assert!(
-            mappings
-                .iter()
-                .any(|m| m.source.ends_with(".bashrc") && m.target.ends_with(".bashrc"))
-        );
-        assert!(
-            mappings
-                .iter()
-                .any(|m| m.source.ends_with(".vimrc") && m.target.ends_with(".vimrc"))
-        );
+        assert!(mappings
+            .iter()
+            .any(|m| m.source.ends_with(".bashrc") && m.target.ends_with(".bashrc")));
+        assert!(mappings
+            .iter()
+            .any(|m| m.source.ends_with(".vimrc") && m.target.ends_with(".vimrc")));
     }
 
     #[test]

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,8 +1,15 @@
-use crate::error::{Result, StauError};
+use crate::error::{map_io_error, Result, StauError};
 use std::path::Path;
 use std::process::Command;
 
-/// Execute a setup or teardown script
+/// Executes a setup or teardown script for a package.
+///
+/// The script is run with the following environment variables set:
+/// - `STAU_DIR`: Path to the dotfiles directory
+/// - `STAU_PACKAGE`: Name of the package being installed/uninstalled
+/// - `STAU_TARGET`: Target directory where symlinks are created
+///
+/// Returns an error if the script fails (non-zero exit code) or cannot be executed.
 pub fn execute_script(
     script_path: &Path,
     package_name: &str,
@@ -29,14 +36,13 @@ pub fn execute_script(
         .env("STAU_TARGET", target_dir)
         .output()
         .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StauError::PermissionDenied(format!(
+            map_io_error(
+                e,
+                format!(
                     "Cannot execute script: {}. Make sure it's executable (chmod +x)",
                     script_path.display()
-                ))
-            } else {
-                StauError::Io(e)
-            }
+                ),
+            )
         })?;
 
     // Print stdout and stderr
@@ -94,10 +100,10 @@ mod tests {
         fs::set_permissions(path, perms).unwrap();
 
         // Sync directory to ensure metadata changes are persisted
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
+        if let Some(parent) = path.parent() {
+            if let Ok(dir) = fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
         }
     }
 

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -1,4 +1,4 @@
-use crate::error::{Result, StauError};
+use crate::error::{map_io_error, Result, StauError};
 use std::fs;
 use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
@@ -13,12 +13,16 @@ pub struct SymlinkMapping {
 }
 
 impl SymlinkMapping {
+    /// Creates a new symlink mapping from source to target.
     pub fn new(source: PathBuf, target: PathBuf) -> Self {
         Self { source, target }
     }
 }
 
-/// Check if a path is a symlink pointing to the expected target
+/// Checks if a path is a symlink pointing to the expected target.
+///
+/// Returns `Ok(true)` if path is a symlink pointing to expected_target,
+/// `Ok(false)` if not a symlink or points elsewhere.
 pub fn is_stau_symlink(path: &Path, expected_target: &Path) -> Result<bool> {
     if !path.exists() && path.symlink_metadata().is_err() {
         return Ok(false);
@@ -39,109 +43,24 @@ pub fn is_stau_symlink(path: &Path, expected_target: &Path) -> Result<bool> {
     }
 }
 
-/// Check if a path or any of its ancestors is a symlink pointing into a dotfiles directory.
-/// This helps detect directory symlinks created by other tools (stow, tuckr, etc.)
-/// Returns the symlink path if found, None otherwise.
-#[allow(dead_code)]
-pub fn find_symlink_in_path(path: &Path, stau_dir: &Path) -> Option<PathBuf> {
-    let mut current = path.to_path_buf();
-
-    while let Some(parent) = current.parent() {
-        if let Ok(metadata) = current.symlink_metadata()
-            && metadata.is_symlink()
-            && let Ok(link_target) = fs::read_link(&current)
-        {
-            // Check if the symlink points into the stau_dir
-            let resolved = if link_target.is_absolute() {
-                link_target
-            } else {
-                parent.join(&link_target)
-            };
-
-            if let Ok(canonical) = resolved.canonicalize()
-                && let Ok(stau_canonical) = stau_dir.canonicalize()
-                && canonical.starts_with(&stau_canonical)
-            {
-                return Some(current);
-            }
-        }
-        current = parent.to_path_buf();
-    }
-    None
-}
-
-/// Check if a path is managed by stau (either directly or via a parent directory symlink)
-#[allow(dead_code)]
-pub fn is_managed_path(path: &Path, expected_target: &Path, stau_dir: &Path) -> Result<bool> {
-    // First check if it's a direct symlink
-    if is_stau_symlink(path, expected_target)? {
-        return Ok(true);
-    }
-
-    // Then check if any parent is a symlink pointing into stau_dir
-    Ok(find_symlink_in_path(path, stau_dir).is_some())
-}
-
-/// Check if a symlink is broken (points to non-existent file)
+/// Checks if a symlink is broken (points to non-existent file).
+///
+/// Returns `true` if path is a symlink whose target doesn't exist,
+/// `false` otherwise (including when path doesn't exist or isn't a symlink).
 pub fn is_broken_symlink(path: &Path) -> bool {
-    if let Ok(metadata) = path.symlink_metadata()
-        && metadata.is_symlink()
-    {
-        // Check if the target exists
-        return !path.exists();
+    if let Ok(metadata) = path.symlink_metadata() {
+        if metadata.is_symlink() {
+            // Check if the target exists
+            return !path.exists();
+        }
     }
     false
 }
 
-/// Remove a directory symlink that points into the dotfiles directory.
-/// This helps users migrate from tools that use directory symlinks (stow, tuckr, etc.)
-/// Returns Ok(true) if a symlink was removed, Ok(false) if not applicable.
-#[allow(dead_code)]
-pub fn remove_directory_symlink(path: &Path, stau_dir: &Path, dry_run: bool) -> Result<bool> {
-    // Check if path is a symlink
-    let metadata = match path.symlink_metadata() {
-        Ok(m) => m,
-        Err(_) => return Ok(false),
-    };
-
-    if !metadata.is_symlink() {
-        return Ok(false);
-    }
-
-    // Check if the symlink points into stau_dir
-    if let Ok(link_target) = fs::read_link(path) {
-        let resolved = if link_target.is_absolute() {
-            link_target
-        } else if let Some(parent) = path.parent() {
-            parent.join(&link_target)
-        } else {
-            link_target
-        };
-
-        if let Ok(canonical) = resolved.canonicalize()
-            && let Ok(stau_canonical) = stau_dir.canonicalize()
-            && canonical.starts_with(&stau_canonical)
-        {
-            if !dry_run {
-                fs::remove_file(path).map_err(|e| {
-                    if e.kind() == std::io::ErrorKind::PermissionDenied {
-                        StauError::PermissionDenied(format!(
-                            "Cannot remove symlink: {}",
-                            path.display()
-                        ))
-                    } else {
-                        StauError::Io(e)
-                    }
-                })?;
-            }
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
-
-/// Create a symlink, ensuring parent directories exist
+/// Creates a symlink at `target` pointing to `source`, creating parent directories as needed.
+///
+/// If the symlink already exists and points to the correct source, this is a no-op.
+/// Returns an error if a conflicting file exists at the target location.
 pub fn create_symlink(source: &Path, target: &Path, dry_run: bool) -> Result<()> {
     // Check if target already exists
     if target.exists() || target.symlink_metadata().is_ok() {
@@ -160,30 +79,21 @@ pub fn create_symlink(source: &Path, target: &Path, dry_run: bool) -> Result<()>
     // Create parent directories if they don't exist
     if let Some(parent) = target.parent() {
         fs::create_dir_all(parent).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StauError::PermissionDenied(format!(
-                    "Cannot create directory: {}",
-                    parent.display()
-                ))
-            } else {
-                StauError::Io(e)
-            }
+            map_io_error(e, format!("Cannot create directory: {}", parent.display()))
         })?;
     }
 
     // Create the symlink
-    unix_fs::symlink(source, target).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            StauError::PermissionDenied(format!("Cannot create symlink: {}", target.display()))
-        } else {
-            StauError::Io(e)
-        }
-    })?;
+    unix_fs::symlink(source, target)
+        .map_err(|e| map_io_error(e, format!("Cannot create symlink: {}", target.display())))?;
 
     Ok(())
 }
 
-/// Remove a symlink if it points to the expected source
+/// Removes a symlink if it points to the expected source.
+///
+/// Returns `Ok(true)` if the symlink was removed, `Ok(false)` if it wasn't a stau-managed symlink.
+/// Only removes symlinks that point to the expected source to avoid removing other symlinks.
 pub fn remove_symlink(path: &Path, expected_source: &Path, dry_run: bool) -> Result<bool> {
     if !is_stau_symlink(path, expected_source)? {
         return Ok(false); // Not our symlink, don't remove
@@ -193,18 +103,15 @@ pub fn remove_symlink(path: &Path, expected_source: &Path, dry_run: bool) -> Res
         return Ok(true);
     }
 
-    fs::remove_file(path).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            StauError::PermissionDenied(format!("Cannot remove symlink: {}", path.display()))
-        } else {
-            StauError::Io(e)
-        }
-    })?;
+    fs::remove_file(path)
+        .map_err(|e| map_io_error(e, format!("Cannot remove symlink: {}", path.display())))?;
 
     Ok(true)
 }
 
-/// Copy a file from source to destination
+/// Copies a file from source to destination, creating parent directories as needed.
+///
+/// Returns an error if the destination already exists to prevent data loss.
 pub fn copy_file(source: &Path, dest: &Path, dry_run: bool) -> Result<()> {
     if dry_run {
         return Ok(());
@@ -217,24 +124,12 @@ pub fn copy_file(source: &Path, dest: &Path, dry_run: bool) -> Result<()> {
     // Create parent directories if they don't exist
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StauError::PermissionDenied(format!(
-                    "Cannot create directory: {}",
-                    parent.display()
-                ))
-            } else {
-                StauError::Io(e)
-            }
+            map_io_error(e, format!("Cannot create directory: {}", parent.display()))
         })?;
     }
 
-    fs::copy(source, dest).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            StauError::PermissionDenied(format!("Cannot copy file: {}", dest.display()))
-        } else {
-            StauError::Io(e)
-        }
-    })?;
+    fs::copy(source, dest)
+        .map_err(|e| map_io_error(e, format!("Cannot copy file: {}", dest.display())))?;
 
     Ok(())
 }
@@ -453,138 +348,5 @@ mod tests {
 
         assert_eq!(mapping1, mapping2);
         assert_ne!(mapping1, mapping3);
-    }
-
-    #[test]
-    fn test_find_symlink_in_path() {
-        let temp_dir = TempDir::new().unwrap();
-        let stau_dir = temp_dir.path().join("dotfiles");
-        let target_dir = temp_dir.path().join("home");
-
-        fs::create_dir(&stau_dir).unwrap();
-        fs::create_dir(&target_dir).unwrap();
-
-        // Create a package with nested structure
-        let package_config = stau_dir.join("vim").join(".config").join("nvim");
-        fs::create_dir_all(&package_config).unwrap();
-        File::create(package_config.join("init.lua")).unwrap();
-
-        // Create a directory symlink (like stow would)
-        let target_config = target_dir.join(".config");
-        unix_fs::symlink(stau_dir.join("vim").join(".config"), &target_config).unwrap();
-
-        // Check that we can find the symlink from a nested path
-        let nested_path = target_config.join("nvim").join("init.lua");
-        let found = find_symlink_in_path(&nested_path, &stau_dir);
-        assert!(found.is_some());
-        assert_eq!(found.unwrap(), target_config);
-    }
-
-    #[test]
-    fn test_find_symlink_in_path_not_found() {
-        let temp_dir = TempDir::new().unwrap();
-        let stau_dir = temp_dir.path().join("dotfiles");
-        let target_dir = temp_dir.path().join("home");
-
-        fs::create_dir(&stau_dir).unwrap();
-        fs::create_dir(&target_dir).unwrap();
-
-        // Create a real directory (not a symlink)
-        let target_config = target_dir.join(".config").join("nvim");
-        fs::create_dir_all(&target_config).unwrap();
-        File::create(target_config.join("init.lua")).unwrap();
-
-        // No symlink should be found
-        let found = find_symlink_in_path(&target_config.join("init.lua"), &stau_dir);
-        assert!(found.is_none());
-    }
-
-    #[test]
-    fn test_remove_directory_symlink() {
-        let temp_dir = TempDir::new().unwrap();
-        let stau_dir = temp_dir.path().join("dotfiles");
-        let target_dir = temp_dir.path().join("home");
-
-        fs::create_dir(&stau_dir).unwrap();
-        fs::create_dir(&target_dir).unwrap();
-
-        // Create a package directory
-        let package_config = stau_dir.join("vim").join(".config");
-        fs::create_dir_all(&package_config).unwrap();
-
-        // Create a directory symlink
-        let target_config = target_dir.join(".config");
-        unix_fs::symlink(&package_config, &target_config).unwrap();
-
-        // Remove the directory symlink
-        let removed = remove_directory_symlink(&target_config, &stau_dir, false).unwrap();
-        assert!(removed);
-        assert!(!target_config.exists());
-    }
-
-    #[test]
-    fn test_remove_directory_symlink_dry_run() {
-        let temp_dir = TempDir::new().unwrap();
-        let stau_dir = temp_dir.path().join("dotfiles");
-        let target_dir = temp_dir.path().join("home");
-
-        fs::create_dir(&stau_dir).unwrap();
-        fs::create_dir(&target_dir).unwrap();
-
-        // Create a package directory
-        let package_config = stau_dir.join("vim").join(".config");
-        fs::create_dir_all(&package_config).unwrap();
-
-        // Create a directory symlink
-        let target_config = target_dir.join(".config");
-        unix_fs::symlink(&package_config, &target_config).unwrap();
-
-        // Dry run should not remove
-        let removed = remove_directory_symlink(&target_config, &stau_dir, true).unwrap();
-        assert!(removed);
-        assert!(target_config.symlink_metadata().is_ok()); // Still exists
-    }
-
-    #[test]
-    fn test_remove_directory_symlink_not_in_stau_dir() {
-        let temp_dir = TempDir::new().unwrap();
-        let stau_dir = temp_dir.path().join("dotfiles");
-        let other_dir = temp_dir.path().join("other");
-        let target_dir = temp_dir.path().join("home");
-
-        fs::create_dir(&stau_dir).unwrap();
-        fs::create_dir(&other_dir).unwrap();
-        fs::create_dir(&target_dir).unwrap();
-
-        // Create a symlink pointing elsewhere (not in stau_dir)
-        let target_config = target_dir.join(".config");
-        unix_fs::symlink(&other_dir, &target_config).unwrap();
-
-        // Should not remove symlinks pointing outside stau_dir
-        let removed = remove_directory_symlink(&target_config, &stau_dir, false).unwrap();
-        assert!(!removed);
-        assert!(target_config.symlink_metadata().is_ok()); // Still exists
-    }
-
-    #[test]
-    fn test_is_managed_path() {
-        let temp_dir = TempDir::new().unwrap();
-        let stau_dir = temp_dir.path().join("dotfiles");
-        let target_dir = temp_dir.path().join("home");
-
-        fs::create_dir(&stau_dir).unwrap();
-        fs::create_dir(&target_dir).unwrap();
-
-        // Create source file
-        let source = stau_dir.join("vim").join(".vimrc");
-        fs::create_dir_all(source.parent().unwrap()).unwrap();
-        File::create(&source).unwrap();
-
-        // Create direct symlink
-        let target = target_dir.join(".vimrc");
-        unix_fs::symlink(&source, &target).unwrap();
-
-        // Should be detected as managed
-        assert!(is_managed_path(&target, &source, &stau_dir).unwrap());
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -41,10 +41,10 @@ fn create_script(path: &std::path::Path, content: &str) {
     fs::set_permissions(path, perms).unwrap();
 
     // Sync directory
-    if let Some(parent) = path.parent()
-        && let Ok(dir) = fs::File::open(parent)
-    {
-        let _ = dir.sync_all();
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix invalid Rust edition 2024 → 2021
- Remove unused `anyhow` dependency
- Remove dead code (~190 lines): `find_symlink_in_path`, `is_managed_path`, `remove_directory_symlink` and their tests
- Add `map_io_error` helper to reduce permission-denied error mapping duplication
- Add doc comments throughout codebase
- Show actual errors in list command instead of generic `[error reading package]`
- Fix let chains for Rust 2021 compatibility

## Test plan
- [x] `cargo build` - compiles successfully
- [x] `cargo clippy` - no warnings
- [x] `cargo test` - all 94 tests pass (51 unit + 43 integration)
- [x] `cargo fmt --check` - properly formatted