### PR TITLE
ci(release): restrict builds to Linux x86_64 only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,15 +102,6 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: stau-linux-x86_64
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            name: stau-macos-x86_64
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            name: stau-macos-aarch64
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            name: stau-windows-x86_64.exe
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -126,33 +117,17 @@ jobs:
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Strip binary (Linux and macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Strip binary
         run: strip target/${{ matrix.target }}/release/stau
 
-      - name: Prepare binary (Linux and macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Prepare binary
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ${{ matrix.name }}.tar.gz stau
           mv ${{ matrix.name }}.tar.gz ../../..
 
-      - name: Prepare binary (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          cd target/${{ matrix.target }}/release
-          7z a ../../../${{ matrix.name }}.zip stau.exe
-
-      - name: Upload to GitHub Release (Linux and macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.release.outputs.new_release_version }}
           files: ${{ matrix.name }}.tar.gz
-
-      - name: Upload to GitHub Release (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ needs.release.outputs.new_release_version }}
-          files: ${{ matrix.name }}.zip

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Traditional tools like GNU Stow excel at symlink management but lack automation 
 - **Broken Symlink Cleanup**: Clean up stale symlinks with the `clean` command
 - **Command Aliases**: Short aliases for common commands (`i`, `u`, `s`, `l`, etc.)
 - **XDG Compliant**: Supports `~/.config/dotfiles` (preferred) and `~/dotfiles` (fallback)
-- **Cross-Platform**: Written in Rust with proper home directory detection on Linux, macOS, and Windows
+- **Linux Native**: Written in Rust for Linux with proper home directory and XDG detection
 
 ## Installation
 
@@ -42,7 +42,7 @@ cargo build --release
 
 ### Pre-built binaries
 
-Download pre-built binaries for Linux, macOS (Intel/Apple Silicon), and Windows from the [releases page](https://github.com/mhalder/stau/releases).
+Download pre-built binaries for Linux x86_64 from the [releases page](https://github.com/mhalder/stau/releases).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Remove macOS and Windows targets from release build matrix
- Simplify workflow steps (remove platform-specific conditionals)
- Update README to reflect Linux x86_64 only support

## Context

The v2.0.2 release failed on Windows because stau uses `std::os::unix::fs` for symlinks, which is not available on Windows.

## Test plan

- [ ] CI passes on this PR
- [ ] Next release builds only Linux x86_64 binary