### PR TITLE
feat(cli): add --all flag to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Download pre-built binaries for Linux x86_64 from the [releases page](https://gi
 # Install a package (creates symlinks + runs setup script)
 stau install ghostty
 
+# Install all packages at once
+stau install --all
+
 # List all packages and their status
 stau list
 
@@ -89,12 +92,13 @@ Organize your dotfiles in a directory structure where each subdirectory is a "pa
 
 ## Commands
 
-### `stau install <package>` (aliases: `i`, `add`)
+### `stau install [package]` (aliases: `i`, `add`)
 
 Creates symlinks from your dotfiles package to the target directory and runs the package's `setup.sh` script if present.
 
 ```bash
 stau install ghostty                    # Basic install
+stau install --all                      # Install all packages
 stau install ghostty --no-setup         # Skip setup script
 stau install ghostty --target /tmp/test # Install to custom directory
 stau install ghostty --dry-run          # Preview without making changes
@@ -104,6 +108,7 @@ stau install ghostty --verbose          # Show detailed output
 **Options:**
 | Flag | Description |
 |------|-------------|
+| `-a, --all` | Install all packages in STAU_DIR |
 | `--no-setup` | Skip running the setup script |
 | `-t, --target <DIR>` | Target directory (default: `$HOME` or `$STAU_TARGET`) |
 | `-n, --dry-run` | Show what would be done without making changes |
@@ -369,7 +374,10 @@ stau automatically ignores these files in package directories:
 # Clone your dotfiles
 git clone https://github.com/username/dotfiles ~/dotfiles
 
-# Install packages
+# Install all packages at once
+stau install --all
+
+# Or install individual packages
 stau install ghostty
 stau install git
 stau install tmux

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,9 @@ pub enum StauError {
 
     #[error("{0}")]
     Other(String),
+
+    #[error("Invalid arguments: {0}")]
+    InvalidArguments(String),
 }
 
 impl StauError {
@@ -59,6 +62,7 @@ impl StauError {
             StauError::InvalidPath(_) => 1,
             StauError::Io(_) => 3,
             StauError::Other(_) => 1,
+            StauError::InvalidArguments(_) => 1,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,12 @@ enum Commands {
     /// Install a package by creating symlinks
     #[command(visible_alias = "i", visible_alias = "add")]
     Install {
-        /// Package name to install
-        package: String,
+        /// Package name to install (required unless --all is specified)
+        package: Option<String>,
+
+        /// Install all packages
+        #[arg(short, long)]
+        all: bool,
 
         /// Target directory (default: $HOME or $STAU_TARGET)
         #[arg(short, long, env = "STAU_TARGET")]
@@ -150,16 +154,34 @@ fn run(cli: Cli) -> Result<()> {
     match cli.command {
         Commands::Install {
             package,
+            all,
             target,
             no_setup,
-        } => install_package(
-            &config,
-            &package,
-            target,
-            no_setup,
-            cli.dry_run,
-            cli.verbose,
-        ),
+        } => {
+            if all && package.is_some() {
+                return Err(error::StauError::InvalidArguments(
+                    "Cannot specify both --all and a package name".to_string(),
+                ));
+            }
+            if !all && package.is_none() {
+                return Err(error::StauError::InvalidArguments(
+                    "Must specify either a package name or --all".to_string(),
+                ));
+            }
+
+            if all {
+                install_all_packages(&config, target, no_setup, cli.dry_run, cli.verbose)
+            } else {
+                install_package(
+                    &config,
+                    package.as_ref().unwrap(),
+                    target,
+                    no_setup,
+                    cli.dry_run,
+                    cli.verbose,
+                )
+            }
+        }
 
         Commands::Uninstall {
             package,
@@ -291,6 +313,63 @@ fn install_package(
         if !dry_run {
             println!("Setup script completed successfully");
         }
+    }
+
+    Ok(())
+}
+
+/// Installs all packages found in STAU_DIR.
+///
+/// For each package, symlinks are created and setup scripts are run (unless skipped).
+/// If any package fails to install, the error is reported but installation continues
+/// for remaining packages.
+fn install_all_packages(
+    config: &Config,
+    target: Option<PathBuf>,
+    no_setup: bool,
+    dry_run: bool,
+    verbose: bool,
+) -> Result<()> {
+    let packages = package::list_packages(&config.stau_dir)?;
+
+    if packages.is_empty() {
+        println!("No packages found in {}", config.stau_dir.display());
+        return Ok(());
+    }
+
+    println!("Installing {} packages...\n", packages.len());
+
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for pkg in &packages {
+        if verbose {
+            println!("--- Installing package: {} ---", pkg);
+        }
+
+        match install_package(config, pkg, target.clone(), no_setup, dry_run, verbose) {
+            Ok(()) => {
+                success_count += 1;
+            }
+            Err(e) => {
+                eprintln!("Failed to install '{}': {}", pkg, e);
+                error_count += 1;
+            }
+        }
+
+        if verbose {
+            println!();
+        }
+    }
+
+    println!();
+    if error_count == 0 {
+        println!("Successfully installed all {} packages", success_count);
+    } else {
+        println!(
+            "Installed {} packages, {} failed",
+            success_count, error_count
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Adds `-a, --all` flag to the `install` command to install all packages in STAU_DIR at once
- Continues installing remaining packages if any individual package fails, reporting errors at the end
- Updates README documentation with new flag usage and examples

## Test plan
- [x] All existing tests pass (51 unit + 46 integration)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes
- [x] Manual test: `stau install --all` installs all packages
- [x] Manual test: `stau install --all vim` returns error about conflicting arguments
- [x] Manual test: `stau install` (no args) returns error about missing package or --all