### PR TITLE
feat(cli): add --all flag to uninstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ stau adopt ghostty ~/.config/ghostty/config
 # Uninstall a package (removes symlinks, copies files back)
 stau uninstall ghostty
 
+# Uninstall all packages at once
+stau uninstall --all
+
 # Refresh symlinks for a package
 stau restow ghostty
 
@@ -114,12 +117,13 @@ stau install ghostty --verbose          # Show detailed output
 | `-n, --dry-run` | Show what would be done without making changes |
 | `-v, --verbose` | Show detailed output |
 
-### `stau uninstall <package>` (aliases: `u`, `rm`)
+### `stau uninstall [package]` (aliases: `u`, `rm`)
 
 Runs `teardown.sh` (if present), removes symlinks, and restores original files from the dotfiles repo. This "unadopts" the dotfiles, leaving you with standalone config files.
 
 ```bash
 stau uninstall ghostty                  # Basic uninstall
+stau uninstall --all                    # Uninstall all packages
 stau uninstall ghostty --no-teardown    # Skip teardown script
 stau uninstall ghostty --dry-run        # Preview without making changes
 ```
@@ -127,6 +131,7 @@ stau uninstall ghostty --dry-run        # Preview without making changes
 **Options:**
 | Flag | Description |
 |------|-------------|
+| `-a, --all` | Uninstall all packages in STAU_DIR |
 | `--no-teardown` | Skip running the teardown script |
 | `-t, --target <DIR>` | Target directory (default: `$HOME` or `$STAU_TARGET`) |
 | `-n, --dry-run` | Show what would be done without making changes |

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,12 @@ enum Commands {
     /// Uninstall a package (removes symlinks and restores original files from dotfiles repo)
     #[command(visible_alias = "u", visible_alias = "rm")]
     Uninstall {
-        /// Package name to uninstall
-        package: String,
+        /// Package name to uninstall (required unless --all is specified)
+        package: Option<String>,
+
+        /// Uninstall all packages
+        #[arg(short, long)]
+        all: bool,
 
         /// Target directory (default: $HOME or $STAU_TARGET)
         #[arg(short, long, env = "STAU_TARGET")]
@@ -185,16 +189,34 @@ fn run(cli: Cli) -> Result<()> {
 
         Commands::Uninstall {
             package,
+            all,
             target,
             no_teardown,
-        } => uninstall_package(
-            &config,
-            &package,
-            target,
-            no_teardown,
-            cli.dry_run,
-            cli.verbose,
-        ),
+        } => {
+            if all && package.is_some() {
+                return Err(error::StauError::InvalidArguments(
+                    "Cannot specify both --all and a package name".to_string(),
+                ));
+            }
+            if !all && package.is_none() {
+                return Err(error::StauError::InvalidArguments(
+                    "Must specify either a package name or --all".to_string(),
+                ));
+            }
+
+            if all {
+                uninstall_all_packages(&config, target, no_teardown, cli.dry_run, cli.verbose)
+            } else {
+                uninstall_package(
+                    &config,
+                    package.as_ref().unwrap(),
+                    target,
+                    no_teardown,
+                    cli.dry_run,
+                    cli.verbose,
+                )
+            }
+        }
 
         Commands::Restow {
             package,
@@ -368,6 +390,63 @@ fn install_all_packages(
     } else {
         println!(
             "Installed {} packages, {} failed",
+            success_count, error_count
+        );
+    }
+
+    Ok(())
+}
+
+/// Uninstalls all packages found in STAU_DIR.
+///
+/// For each package, teardown scripts are run (unless skipped) and symlinks are removed.
+/// If any package fails to uninstall, the error is reported but uninstallation continues
+/// for remaining packages.
+fn uninstall_all_packages(
+    config: &Config,
+    target: Option<PathBuf>,
+    no_teardown: bool,
+    dry_run: bool,
+    verbose: bool,
+) -> Result<()> {
+    let packages = package::list_packages(&config.stau_dir)?;
+
+    if packages.is_empty() {
+        println!("No packages found in {}", config.stau_dir.display());
+        return Ok(());
+    }
+
+    println!("Uninstalling {} packages...\n", packages.len());
+
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for pkg in &packages {
+        if verbose {
+            println!("--- Uninstalling package: {} ---", pkg);
+        }
+
+        match uninstall_package(config, pkg, target.clone(), no_teardown, dry_run, verbose) {
+            Ok(()) => {
+                success_count += 1;
+            }
+            Err(e) => {
+                eprintln!("Failed to uninstall '{}': {}", pkg, e);
+                error_count += 1;
+            }
+        }
+
+        if verbose {
+            println!();
+        }
+    }
+
+    println!();
+    if error_count == 0 {
+        println!("Successfully uninstalled all {} packages", success_count);
+    } else {
+        println!(
+            "Uninstalled {} packages, {} failed",
             success_count, error_count
         );
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1551,3 +1551,550 @@ fn test_adopt_dry_run() {
     // Package directory should not be created
     assert!(!stau_dir.join("bash").exists());
 }
+
+// =============================================================================
+// Tests for install --all
+// =============================================================================
+
+#[test]
+fn test_install_all_packages() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create multiple packages
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+    create_test_package(&stau_dir, "bash", &[".bashrc"]);
+
+    // Install all packages
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Install --all failed: {:?}",
+        output
+    );
+
+    // All packages should be installed
+    assert!(target_dir.join(".vimrc").is_symlink());
+    assert!(target_dir.join(".gitconfig").is_symlink());
+    assert!(target_dir.join(".bashrc").is_symlink());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Installing 3 packages"));
+    assert!(stdout.contains("Successfully installed all 3 packages"));
+}
+
+#[test]
+fn test_install_all_with_empty_stau_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Install --all with no packages
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("No packages found"));
+}
+
+#[test]
+fn test_install_all_with_no_setup() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create packages with setup scripts
+    let vim_dir = stau_dir.join("vim");
+    fs::create_dir(&vim_dir).unwrap();
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+
+    let marker_file = target_dir.join("setup-ran");
+    let setup_script = vim_dir.join("setup.sh");
+    create_script(
+        &setup_script,
+        &format!("#!/bin/bash\ntouch {}\n", marker_file.display()),
+    );
+
+    // Install --all with --no-setup
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all", "--no-setup"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(target_dir.join(".vimrc").is_symlink());
+    assert!(!marker_file.exists(), "Setup script should NOT have run");
+}
+
+#[test]
+fn test_install_all_with_dry_run() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+
+    // Install --all with --dry-run
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // No files should be created (dry run)
+    assert!(!target_dir.join(".vimrc").exists());
+    assert!(!target_dir.join(".gitconfig").exists());
+}
+
+#[test]
+fn test_install_all_partial_failure() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create packages
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+
+    // Create a conflict for vim
+    fs::write(target_dir.join(".vimrc"), "existing content").unwrap();
+
+    // Install --all should continue despite one failure
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all"])
+        .output()
+        .unwrap();
+
+    // Command succeeds overall (returns success even with partial failures)
+    assert!(output.status.success());
+
+    // git should be installed despite vim failure
+    assert!(target_dir.join(".gitconfig").is_symlink());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("1 failed"));
+}
+
+#[test]
+fn test_install_all_and_package_mutual_exclusion() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+
+    // Try to use both --all and a package name
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all", "vim"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Cannot specify both --all and a package name"));
+}
+
+#[test]
+fn test_install_requires_package_or_all() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Try to install without package or --all
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Must specify either a package name or --all"));
+}
+
+// =============================================================================
+// Tests for uninstall --all
+// =============================================================================
+
+#[test]
+fn test_uninstall_all_packages() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create and install multiple packages
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+    create_test_package(&stau_dir, "bash", &[".bashrc"]);
+
+    // Install all first
+    let _ = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all"])
+        .output()
+        .unwrap();
+
+    // Verify they're installed
+    assert!(target_dir.join(".vimrc").is_symlink());
+    assert!(target_dir.join(".gitconfig").is_symlink());
+    assert!(target_dir.join(".bashrc").is_symlink());
+
+    // Uninstall all packages
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Uninstall --all failed: {:?}",
+        output
+    );
+
+    // All files should be regular files now (not symlinks)
+    assert!(!target_dir.join(".vimrc").is_symlink());
+    assert!(!target_dir.join(".gitconfig").is_symlink());
+    assert!(!target_dir.join(".bashrc").is_symlink());
+
+    // Files should still exist (copied back)
+    assert!(target_dir.join(".vimrc").exists());
+    assert!(target_dir.join(".gitconfig").exists());
+    assert!(target_dir.join(".bashrc").exists());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Uninstalling 3 packages"));
+    assert!(stdout.contains("Successfully uninstalled all 3 packages"));
+}
+
+#[test]
+fn test_uninstall_all_with_empty_stau_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Uninstall --all with no packages
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("No packages found"));
+}
+
+#[test]
+fn test_uninstall_all_with_no_teardown() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create package with teardown script
+    let vim_dir = stau_dir.join("vim");
+    fs::create_dir(&vim_dir).unwrap();
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+
+    let marker_file = target_dir.join("teardown-ran");
+    let teardown_script = vim_dir.join("teardown.sh");
+    create_script(
+        &teardown_script,
+        &format!("#!/bin/bash\ntouch {}\n", marker_file.display()),
+    );
+
+    // Install first
+    let _ = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "vim", "--no-setup"])
+        .output()
+        .unwrap();
+
+    // Uninstall --all with --no-teardown
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all", "--no-teardown"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(!target_dir.join(".vimrc").is_symlink());
+    assert!(!marker_file.exists(), "Teardown script should NOT have run");
+}
+
+#[test]
+fn test_uninstall_all_with_dry_run() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+
+    // Install all first
+    let _ = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all"])
+        .output()
+        .unwrap();
+
+    // Uninstall --all with --dry-run
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // Symlinks should still exist (dry run doesn't actually uninstall)
+    assert!(target_dir.join(".vimrc").is_symlink());
+    assert!(target_dir.join(".gitconfig").is_symlink());
+}
+
+#[test]
+fn test_uninstall_all_partial_failure() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create packages
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+    create_test_package(&stau_dir, "nonexistent_in_source", &[".config"]);
+
+    // Install only vim and git
+    let _ = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "vim"])
+        .output()
+        .unwrap();
+
+    let _ = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "git"])
+        .output()
+        .unwrap();
+
+    // Delete the source file for nonexistent_in_source to create a scenario where
+    // uninstall will work but may encounter issues
+    fs::remove_dir_all(stau_dir.join("nonexistent_in_source")).unwrap();
+    fs::create_dir(stau_dir.join("nonexistent_in_source")).unwrap();
+
+    // Uninstall --all should continue despite one having no symlinks
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all"])
+        .output()
+        .unwrap();
+
+    // Command succeeds overall
+    assert!(output.status.success());
+
+    // vim and git should be uninstalled
+    assert!(!target_dir.join(".vimrc").is_symlink());
+    assert!(!target_dir.join(".gitconfig").is_symlink());
+}
+
+#[test]
+fn test_uninstall_all_and_package_mutual_exclusion() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+
+    // Try to use both --all and a package name
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all", "vim"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Cannot specify both --all and a package name"));
+}
+
+#[test]
+fn test_uninstall_requires_package_or_all() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Try to uninstall without package or --all
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Must specify either a package name or --all"));
+}
+
+#[test]
+fn test_uninstall_all_runs_teardown_scripts() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create packages with teardown scripts
+    let vim_dir = stau_dir.join("vim");
+    fs::create_dir(&vim_dir).unwrap();
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+
+    let git_dir = stau_dir.join("git");
+    fs::create_dir(&git_dir).unwrap();
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+
+    let vim_marker = target_dir.join("vim-teardown-ran");
+    let git_marker = target_dir.join("git-teardown-ran");
+
+    create_script(
+        &vim_dir.join("teardown.sh"),
+        &format!("#!/bin/bash\ntouch {}\n", vim_marker.display()),
+    );
+    create_script(
+        &git_dir.join("teardown.sh"),
+        &format!("#!/bin/bash\ntouch {}\n", git_marker.display()),
+    );
+
+    // Install all first (without setup)
+    let _ = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all", "--no-setup"])
+        .output()
+        .unwrap();
+
+    // Uninstall --all (teardown should run by default)
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(vim_marker.exists(), "Vim teardown script should have run");
+    assert!(git_marker.exists(), "Git teardown script should have run");
+}
+
+#[test]
+fn test_uninstall_all_verbose() {
+    let temp_dir = TempDir::new().unwrap();
+    let stau_dir = temp_dir.path().join("dotfiles");
+    let target_dir = temp_dir.path().join("home");
+
+    fs::create_dir(&stau_dir).unwrap();
+    fs::create_dir(&target_dir).unwrap();
+
+    create_test_package(&stau_dir, "vim", &[".vimrc"]);
+    create_test_package(&stau_dir, "git", &[".gitconfig"]);
+
+    // Install all first
+    let _ = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["install", "--all"])
+        .output()
+        .unwrap();
+
+    // Uninstall --all with --verbose
+    let output = Command::new(stau_binary())
+        .env("STAU_DIR", &stau_dir)
+        .env("STAU_TARGET", &target_dir)
+        .args(["uninstall", "--all", "--verbose"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Verbose output should show package-by-package progress
+    assert!(stdout.contains("--- Uninstalling package:"));
+    assert!(stdout.contains("Package directory:") || stdout.contains("STAU_DIR:"));
+}


### PR DESCRIPTION
## Summary

- Add `--all` flag to uninstall command for batch uninstallation of all packages
- Include validation to ensure mutual exclusion between `--all` and package name argument
- Add comprehensive integration tests for both `install --all` and `uninstall --all`
- Update README documentation with new flag usage

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` passes  
- [x] `cargo fmt` passes
- [x] All 113 tests pass (51 unit + 62 integration)
- [x] Manual testing: `stau uninstall --all --dry-run`
- [x] Manual testing: `stau uninstall --all vim` (errors as expected)
- [x] Manual testing: `stau uninstall` (errors as expected)