### PR TITLE
fix(test): use CARGO_BIN_EXE for binary lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust
 /target/
+/build/
 Cargo.lock
 
 # IDEs

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,11 +7,7 @@ use tempfile::TempDir;
 
 /// Helper to get the path to the stau binary
 fn stau_binary() -> PathBuf {
-    let mut path = std::env::current_exe().unwrap();
-    path.pop(); // Remove test binary name
-    path.pop(); // Remove 'deps'
-    path.push("stau");
-    path
+    PathBuf::from(env!("CARGO_BIN_EXE_stau"))
 }
 
 /// Helper to create a test package with files


### PR DESCRIPTION
## Summary
- Replace manual path construction (`current_exe()` + pop/pop/push) with `env!("CARGO_BIN_EXE_stau")` for locating the binary in integration tests
- Add `/build/` to `.gitignore` for custom build directories

Closes #20

## Test plan
- [x] `cargo test` — all 113 tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — no changes
- [x] `CARGO_BUILD_BUILD_DIR=build cargo test` — passes (the exact reproduction case from the issue)